### PR TITLE
✨ feat : 로그인 & 회원가입 api 연동

### DIFF
--- a/src/apis/axois.ts
+++ b/src/apis/axois.ts
@@ -1,0 +1,7 @@
+import { BASE_URL } from '@/constants';
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: BASE_URL,
+  headers: { 'Content-Type': 'application/json' }
+});

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,0 +1,1 @@
+export * from './userApi';

--- a/src/apis/user/userApi.ts
+++ b/src/apis/user/userApi.ts
@@ -1,0 +1,21 @@
+import { BASE_URL } from '@/constants';
+import { api } from '../axois';
+
+export const userApi = {
+  // 카카오 로그인
+  kakaoLogin: `${BASE_URL}/oauth2/authorization/kakao?redirect_uri=http://localhost:5173/join`,
+  // 유저 조회
+  getInfo: (token: string) =>
+    api.get('/api/members', {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }),
+  // 닉네임 추가
+  addNickname: (token: string) =>
+    api.patch('/api/members/nickname', {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+};

--- a/src/apis/user/userApi.ts
+++ b/src/apis/user/userApi.ts
@@ -1,21 +1,25 @@
-import { BASE_URL } from '@/constants';
+import { BASE_URL, REDIRECT_URI } from '@/constants';
 import { api } from '../axois';
 
 export const userApi = {
   // 카카오 로그인
-  kakaoLogin: `${BASE_URL}/oauth2/authorization/kakao?redirect_uri=http://localhost:5173/join`,
+  kakaoLogin: `${BASE_URL}/oauth2/authorization/kakao?redirect_uri=${REDIRECT_URI}`,
   // 유저 조회
   getInfo: (token: string) =>
     api.get('/api/members', {
       headers: {
-        Authorization: `Bearer ${token}`
+        Authorization: token
       }
     }),
   // 닉네임 추가
-  addNickname: (token: string) =>
-    api.patch('/api/members/nickname', {
-      headers: {
-        Authorization: `Bearer ${token}`
+  addNickname: (nickname: string, token: string) =>
+    api.patch(
+      '/api/members/nickname',
+      { nickname },
+      {
+        headers: {
+          Authorization: token
+        }
       }
-    })
+    )
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = 'http://facerain-dev.iptime.org:8080';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
 export const BASE_URL = 'http://facerain-dev.iptime.org:8080';
+export const REDIRECT_URI = 'http://localhost:5173/join';

--- a/src/pages/join/complete.tsx
+++ b/src/pages/join/complete.tsx
@@ -2,6 +2,7 @@ import { IconJoinComplete } from '@/assets/IconJoinComplete';
 import { Space } from '@/components/Wrapper';
 import { Button } from '@/components/common/Button';
 import { Header } from '@/components/common/Header';
+import { media } from '@/styles';
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
@@ -53,6 +54,10 @@ const StyledGraphic = styled.div`
   justify-content: center;
   width: 37.5rem;
   margin-left: -2rem;
+
+  ${media.mobile} {
+    width: 100vw;
+  }
 `;
 
 const StyledTitle = styled.div`
@@ -71,6 +76,10 @@ const StyledButton = styled.div`
   bottom: 4.4rem;
   width: 100%;
   max-width: calc(37.5rem - 4rem);
+
+  ${media.mobile} {
+    max-width: calc(100% - 4rem);
+  }
 `;
 
 export default JoinComplete;

--- a/src/pages/join/index.tsx
+++ b/src/pages/join/index.tsx
@@ -32,6 +32,7 @@ const Join = () => {
     if (token) {
       try {
         await userApi.addNickname(nickname, token);
+        document.cookie = `token=${token}`;
         navigate('/join/complete');
       } catch {
         navigate('/onboarding');

--- a/src/pages/join/index.tsx
+++ b/src/pages/join/index.tsx
@@ -1,11 +1,13 @@
+import { userApi } from '@/apis/user';
 import { Space } from '@/components/Wrapper';
 import { Button } from '@/components/common/Button';
 import { Header } from '@/components/common/Header';
 import { Input } from '@/components/common/Input';
 import { media } from '@/styles';
 import styled from '@emotion/styled';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 const Join = () => {
   const {
@@ -21,15 +23,41 @@ const Join = () => {
     mode: 'onChange'
   });
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('code');
 
   const handleJoin = async () => {
-    try {
-      await console.log(getValues('join'));
-      navigate('/join/complete');
-    } catch {
-      console.log('error');
+    const nickname = getValues('join');
+
+    if (token) {
+      try {
+        await userApi.addNickname(nickname, token);
+        navigate('/join/complete');
+      } catch {
+        navigate('/onboarding');
+      }
+    } else {
+      navigate('/onboarding');
     }
   };
+
+  const getUserData = async () => {
+    if (token) {
+      try {
+        const { data } = await userApi.getInfo(token);
+        const nickname = data?.response?.nickname;
+        setValue('join', nickname);
+      } catch {
+        navigate('/onboarding');
+      }
+    } else {
+      navigate('/onboarding');
+    }
+  };
+
+  useEffect(() => {
+    getUserData();
+  }, []);
   return (
     <StyledContainer>
       <Header

--- a/src/pages/join/index.tsx
+++ b/src/pages/join/index.tsx
@@ -2,6 +2,7 @@ import { Space } from '@/components/Wrapper';
 import { Button } from '@/components/common/Button';
 import { Header } from '@/components/common/Header';
 import { Input } from '@/components/common/Input';
+import { media } from '@/styles';
 import styled from '@emotion/styled';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -98,6 +99,10 @@ const StyledButton = styled.div`
   transform: translateX(-50%);
   width: 100%;
   max-width: calc(37.5rem - 4rem);
+
+  ${media.mobile} {
+    max-width: calc(100% - 4rem);
+  }
 `;
 
 export default Join;

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -1,15 +1,26 @@
 import { IconOnboardingBackground } from '@/assets/IconOnboardingBackground';
 import { SvgIcon } from '@/components/common/SvgIcon';
+import { media } from '@/styles';
 import styled from '@emotion/styled';
 
 const Onboarding = () => {
+  const handleLogin = async () => {
+    const response = await fetch(
+      'http://facerain-dev.iptime.org:8080/oauth2/authorization/kakao?redirect_uri=http://localhost:5173/join',
+      {
+        method: 'GET'
+      }
+    );
+    const data = await response.json();
+    console.log(data);
+  };
   return (
     <StyledContainer>
       <StyledGraphic>
         <IconOnboardingBackground />
       </StyledGraphic>
 
-      <StyledButton>
+      <StyledButton onClick={handleLogin}>
         <SvgIcon id="kakao" /> 카카오로 계속하기
       </StyledButton>
     </StyledContainer>
@@ -24,11 +35,15 @@ const StyledContainer = styled.div`
 const StyledGraphic = styled.div`
   width: 37.5rem;
   margin-left: -2rem;
-  height: 300px;
+  /* height: 300px; */
+
+  ${media.mobile} {
+    width: 100vw;
+  }
 `;
 
 const StyledButton = styled.button`
-  position: absolute;
+  position: fixed;
   bottom: 4.4rem;
   display: flex;
   justify-content: center;
@@ -45,6 +60,10 @@ const StyledButton = styled.button`
   &:hover,
   &:focus {
     opacity: 0.8;
+  }
+
+  ${media.mobile} {
+    max-width: calc(100% - 4rem);
   }
 `;
 

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -1,28 +1,22 @@
+import { userApi } from '@/apis/user';
 import { IconOnboardingBackground } from '@/assets/IconOnboardingBackground';
 import { SvgIcon } from '@/components/common/SvgIcon';
 import { media } from '@/styles';
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 
 const Onboarding = () => {
-  const handleLogin = async () => {
-    const response = await fetch(
-      'http://facerain-dev.iptime.org:8080/oauth2/authorization/kakao?redirect_uri=http://localhost:5173/join',
-      {
-        method: 'GET'
-      }
-    );
-    const data = await response.json();
-    console.log(data);
-  };
   return (
     <StyledContainer>
       <StyledGraphic>
         <IconOnboardingBackground />
       </StyledGraphic>
 
-      <StyledButton onClick={handleLogin}>
-        <SvgIcon id="kakao" /> 카카오로 계속하기
-      </StyledButton>
+      <Link to={userApi.kakaoLogin}>
+        <StyledButton>
+          <SvgIcon id="kakao" /> 카카오로 계속하기
+        </StyledButton>
+      </Link>
     </StyledContainer>
   );
 };
@@ -35,7 +29,6 @@ const StyledContainer = styled.div`
 const StyledGraphic = styled.div`
   width: 37.5rem;
   margin-left: -2rem;
-  /* height: 300px; */
 
   ${media.mobile} {
     width: 100vw;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -18,3 +18,11 @@ export type KeyofTheme = keyof typeof theme;
 
 export type TypeOfTypo = typeof typo;
 export type KeyOfTypo = keyof typeof typo;
+
+export const customMediaQuery = (minWidth: number): string =>
+  `@media (min-width: ${minWidth}px)`;
+export const media = {
+  custom: customMediaQuery,
+  pc: customMediaQuery(767),
+  mobile: `@media (max-width : 767px)`
+};

--- a/src/utils/getCookie.ts
+++ b/src/utils/getCookie.ts
@@ -1,0 +1,7 @@
+export const getCookie = (name: string) => {
+  const cookieValue = document.cookie
+    .split('; ')
+    .find((cookie) => cookie.startsWith(`${name}=`));
+
+  return cookieValue ? cookieValue.split('=')[1] : null;
+};


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolved: #24 

## 🌱 PR 포인트

- 로그인과 회원가입 기능의 api 연동 완료했습니다.
- api는 컨트롤러 또는 도메인 별로 관리할 수 있도록 작성했습니다.
- token 값은 cookie에 저장하고 있습니다. (`expires` 또는 `max-age`와 같은 속성 값은 다 같이 얘기해보는게 좋을 것 같습니당)
- cookie 값을 가져오는 `getCookie` util 함수를 작성했습니다. 사용 방법은 다음과 같습니다.
```tsx
import { getCookie } from '@/utils/getCookie';

getCookie(token)
```
- 현재 카카오 로그인 완료할 때의 `redirect_uri`가 회원가입 페이지로 설정되어 있는데, 이 부분도 추후 다 같이 얘기해보면 좋을 것 같아용

## 📸 스크린샷 / 링크

| 쿠키 |
| :------: |
| <img width="1514" alt="스크린샷 2024-02-22 오전 3 28 02" src="https://github.com/dnd-side-project/dnd-10th-2-frontend/assets/61397627/ed4e80c2-ee0e-4a76-85ad-fcbd978eaf2f"> |

## 📎 레퍼런스

- [cookie 속성 값](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie)

## ❗ 이슈사항 / 기타사항 / 에러슈팅

- 사용자 최초 접속 시 cookie의 token 값에 따른 사용자 정보 상태 관리가 필요할 것 같은데, 어떤 방식이 좋을까요?
- 로그인 여부에 따른 페이지 접근 권한은 페이지 UI 작성 완료 후 설정할 예정입니다.
