### PR TITLE
✨ feat: 바텀시트의 시간 및 날짜 스와이프 시 닫힘 방지 기능 작성

### DIFF
--- a/src/features/meeting/ui/AgendaSheet.tsx
+++ b/src/features/meeting/ui/AgendaSheet.tsx
@@ -12,6 +12,7 @@ import { useBottomSheet, useTimePicker } from '@shared/common/hooks';
 
 import { formatDuration } from '@features/meeting-create/utils';
 import { AddAgendaMessage } from '@/shared/meeting/apis';
+import { css } from '@emotion/react';
 
 export const AgendaSheet = ({
   type,
@@ -27,9 +28,10 @@ export const AgendaSheet = ({
     formState: { errors }
   } = useForm({ defaultValues: { agendaTitle: '' }, mode: 'onChange' });
 
-  const { closeBottomSheet } = useBottomSheet();
+  const { closeBottomSheet, setDismissibleTrue, setDismissibleFalse } =
+    useBottomSheet();
 
-  const { timePicker, setTime, closeTimePicker } = useTimePicker();
+  const { timePicker, setTime } = useTimePicker();
 
   const addAgendaMessage = {
     title: getValues('agendaTitle'),
@@ -78,7 +80,14 @@ export const AgendaSheet = ({
 
       <Space height={16} />
 
-      <TimePicker type="duration" setTime={setTime} onClose={closeTimePicker} />
+      <div
+        onPointerEnter={setDismissibleFalse}
+        onPointerLeave={setDismissibleTrue}
+        css={css`
+          width: 100%;
+        `}>
+        <TimePicker type="duration" setTime={setTime} />
+      </div>
 
       <Space height={24} />
 

--- a/src/shared/common/hooks/useBottomSheet.ts
+++ b/src/shared/common/hooks/useBottomSheet.ts
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 
 type BottomSheetType = {
   isOpened: boolean;
+  dismissible?: boolean;
   content: ReactNode;
 };
 
@@ -14,20 +15,35 @@ interface BotttomSheetStoreType {
     content: BottomSheetType['content'];
   }) => void;
   closeBottomSheet: () => void;
+  setDismissibleTrue: () => void;
+  setDismissibleFalse: () => void;
 }
 
 export const useBottomSheet = create<BotttomSheetStoreType>((set) => ({
   bottomSheet: {
     isOpened: false,
+    dismissible: true,
     content: null
   },
   openBottomSheet: ({ content }) => {
-    set(() => ({ bottomSheet: { isOpened: true, content } }));
+    set(() => ({
+      bottomSheet: { isOpened: true, dismissible: true, content }
+    }));
   },
   closeBottomSheet: () => {
     set((prev) => ({ bottomSheet: { ...prev.bottomSheet, isOpened: false } }));
     setTimeout(() => {
       set((prev) => ({ bottomSheet: { ...prev.bottomSheet, content: null } }));
     }, 100);
+  },
+  setDismissibleTrue: () => {
+    set((prev) => ({
+      bottomSheet: { ...prev.bottomSheet, dismissible: true }
+    }));
+  },
+  setDismissibleFalse: () => {
+    set((prev) => ({
+      bottomSheet: { ...prev.bottomSheet, dismissible: false }
+    }));
   }
 }));

--- a/src/shared/common/ui/BottomSheet/BottomSheet.tsx
+++ b/src/shared/common/ui/BottomSheet/BottomSheet.tsx
@@ -6,11 +6,11 @@ import { media } from '@shared/common/styles';
 
 export const BottomSheet = () => {
   const {
-    bottomSheet: { isOpened, content },
+    bottomSheet: { isOpened, dismissible, content },
     closeBottomSheet
   } = useBottomSheet();
   return (
-    <Drawer.Root open={isOpened}>
+    <Drawer.Root open={isOpened} dismissible={dismissible}>
       <Drawer.Portal>
         <StyledOverlay />
         <StyledContent


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolved: #102 

## 🌱 PR 포인트

- 바텀시트에 있는 시간 및 날짜를 선택할 때, 하단으로 스와이프시 바텀시트가 닫히는 현상을 방지하는 기능을 추가하였습니다.
  - `dismissible` prop과 pointer 이벤트를 활용하였습니다.

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

## ❗ 이슈사항 / 기타사항 / 에러슈팅
