### PR TITLE
🐛 fix: Timer 컴포넌트의 남은 시간 에러 수정

### DIFF
--- a/src/features/meeting/ui/Timer.tsx
+++ b/src/features/meeting/ui/Timer.tsx
@@ -10,6 +10,7 @@ import { theme } from '@shared/common/styles';
 import { ControlAgendaMessage } from '@shared/meeting/apis';
 
 import { formatSeconds, formatEndTime } from '@features/meeting/utils';
+import { useEffect, useState } from 'react';
 
 /**
  * @default button: (button 태그 속성 그대로)
@@ -28,6 +29,14 @@ export const Timer = ({
   isPlaying: boolean;
   sendControlAgendaMessage: (message: ControlAgendaMessage) => void;
 }) => {
+  const [timerKey, setTimerKey] = useState(0);
+
+  // isPlaying이 false로 변경될 때 타이머 상태를 리셋
+  useEffect(() => {
+    if (!isPlaying) {
+      setTimerKey((prev) => prev + 1);
+    }
+  }, [isPlaying]);
   return (
     <TimerWrapper justify="flex-start" direction="column">
       <Chip>
@@ -35,12 +44,14 @@ export const Timer = ({
       </Chip>
       <Gradient />
       <CountdownCircleTimer
+        key={timerKey}
         colors={'url(#blue-gradient)'}
         isPlaying={isPlaying}
         size={260}
         rotation="counterclockwise"
         isGrowing={true}
         duration={time}
+        initialRemainingTime={time}
         trailColor={theme.palette.timer_trail as ColorFormat}
         strokeWidth={13}
         onComplete={() => {

--- a/src/shared/common/constants/index.ts
+++ b/src/shared/common/constants/index.ts
@@ -1,2 +1,2 @@
-export const BASE_URL = 'http://facerain-dev.iptime.org:8080';
+export const BASE_URL = 'https://facerain-dev.duckdns.org';
 export const BROKER_URL = 'ws://facerain-dev.iptime.org:8080/ws';


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolved: #104 

## 🌱 PR 포인트

- Timer 컴포넌트의 `isPlaying` prop 값이 true에서 false로 변경될 때, 남은 시간이 예정보다 많이 줄어드는 현상 해결 완료했습니다.
  - `key` prop을 추가해, `isPlaying`이 false로 변경될 때 타이머 상태를 리셋합니다.

## 📸 스크린샷 / 링크

| 스크린샷 |
| :------: |
| 사진첨부 |

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

- [타이머 라이브러리의 key prop](https://www.npmjs.com/package/react-countdown-circle-timer#restart-timer-at-any-given-time)

## ❗ 이슈사항 / 기타사항 / 에러슈팅

- api의 `BASE_URL`을 변경했습니다.
